### PR TITLE
Fail on error of "getSpecs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-load-balancer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Zachary J. Hamm",
   "license": "MIT",
   "repository": "https://github.com/hammzj/cypress-load-balancer/",

--- a/src/cli/commands/balance.ts
+++ b/src/cli/commands/balance.ts
@@ -29,7 +29,7 @@ export default {
   command: "$0",
   description: "Performs load balancing against a set of runners and Cypress specs",
   //@ts-expect-error Figuring out the type later
-  builder: function(yargs) {
+  builder: function (yargs) {
     return (
       yargs
         .option("runners", {
@@ -89,25 +89,25 @@ export default {
         .help()
         .alias("help", "h")
         .example(
-          "Load balancing for 6 runners against \"component\" testing with implied Cypress configuration of `./cypress.config.js`",
+          'Load balancing for 6 runners against "component" testing with implied Cypress configuration of `./cypress.config.js`',
           "npx cypressLoadBalancer -r 6 -t component"
         )
         .example(
-          "Load balancing for 6 runners against \"component\" testing with an explicit Cypress configuration set by an environment variable",
+          'Load balancing for 6 runners against "component" testing with an explicit Cypress configuration set by an environment variable',
           "CYPRESS_CONFIG_FILE=./src/tests/cypress.config.js npx cypressLoadBalancer -r 6 -t e2e"
         )
         .example(
-          "Load balancing for 3 runners against \"e2e\" testing with specified file paths",
+          'Load balancing for 3 runners against "e2e" testing with specified file paths',
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js cypress/e2e/bar.cy.js cypress/e2e/wee.cy.js"
         )
         .example(
-          "Load balancing for 3 runners against \"e2e\" testing with a specified glob pattern and file path",
+          'Load balancing for 3 runners against "e2e" testing with a specified glob pattern and file path',
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js -G cypress/e2e/more_tests/*.cy.js"
         )
     );
   },
   //@ts-expect-error Figuring out the type later
-  handler: function(argv) {
+  handler: function (argv) {
     //Assign files array to detect "--files" or files found "--glob" patterns first
     let files: string[] = argv.files;
     files.push(...glob.globSync(argv.glob));
@@ -120,12 +120,7 @@ export default {
       }
     } catch (e) {
       const error = new GetSpecsError(argv["testing-type"], { cause: e });
-      console.error(
-        error.name,
-        error.message,
-        `Testing Type: ${error.testingType}`,
-        `Cause:`,
-        e);
+      console.error(error.name, error.message, `Testing Type: ${error.testingType}`, `Cause:`, e);
       throw error;
     }
 

--- a/src/cli/commands/balance.ts
+++ b/src/cli/commands/balance.ts
@@ -8,6 +8,7 @@ import { glob } from "glob";
 import performLoadBalancing from "../../loadBalancer";
 import { Runners, TestingType } from "../../types";
 import utils from "../../utils";
+import { GetSpecsError } from "../errors";
 
 type FormatOutputOption = "spec" | "string" | "newline";
 
@@ -118,24 +119,28 @@ export default {
         files = getSpecs(undefined, argv[`testing-type`]);
       }
     } catch (e) {
+      const error = new GetSpecsError(argv["testing-type"], { cause: e });
       console.error(
-        "Could not run `getSpecs` most likely do to an incorrect Cypress configuration or missing testing type",
-        argv[`testing-type`],
-        "Original error",
-        e
-      );
-      //TODO: add custom error and pass cause to `console.error
-      throw Error(`Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}\n${e}`);
+        error.name,
+        error.message,
+        `Testing Type: ${error.testingType}`,
+        `Cause:`,
+        e);
+      throw error;
     }
+
     const output: Runners | string[] = performLoadBalancing(argv.runners, argv["testing-type"] as TestingType, [
       ...new Set(files)
     ]);
+
     argv.output = JSON.stringify(formatOutput(output, argv.format));
 
     if (argv[`set-gha-output`]) {
       setOutput("cypressLoadBalancerSpecs", argv.output);
     }
-    if (process.env.CYPRESS_LOAD_BALANCER_DEBUG !== "true") console.clear();
+    if (process.env.CYPRESS_LOAD_BALANCER_DEBUG !== "true") {
+      console.clear();
+    }
     console.log(argv.output);
   }
 };

--- a/src/cli/commands/balance.ts
+++ b/src/cli/commands/balance.ts
@@ -28,7 +28,7 @@ export default {
   command: "$0",
   description: "Performs load balancing against a set of runners and Cypress specs",
   //@ts-expect-error Figuring out the type later
-  builder: function(yargs) {
+  builder: function (yargs) {
     return (
       yargs
         .option("runners", {
@@ -88,25 +88,25 @@ export default {
         .help()
         .alias("help", "h")
         .example(
-          "Load balancing for 6 runners against \"component\" testing with implied Cypress configuration of `./cypress.config.js`",
+          'Load balancing for 6 runners against "component" testing with implied Cypress configuration of `./cypress.config.js`',
           "npx cypressLoadBalancer -r 6 -t component"
         )
         .example(
-          "Load balancing for 6 runners against \"component\" testing with an explicit Cypress configuration set by an environment variable",
+          'Load balancing for 6 runners against "component" testing with an explicit Cypress configuration set by an environment variable',
           "CYPRESS_CONFIG_FILE=./src/tests/cypress.config.js npx cypressLoadBalancer -r 6 -t e2e"
         )
         .example(
-          "Load balancing for 3 runners against \"e2e\" testing with specified file paths",
+          'Load balancing for 3 runners against "e2e" testing with specified file paths',
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js cypress/e2e/bar.cy.js cypress/e2e/wee.cy.js"
         )
         .example(
-          "Load balancing for 3 runners against \"e2e\" testing with a specified glob pattern and file path",
+          'Load balancing for 3 runners against "e2e" testing with a specified glob pattern and file path',
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js -G cypress/e2e/more_tests/*.cy.js"
         )
     );
   },
   //@ts-expect-error Figuring out the type later
-  handler: function(argv) {
+  handler: function (argv) {
     //Assign files array to detect "--files" or files found "--glob" patterns first
     let files: string[] = argv.files;
     files.push(...glob.globSync(argv.glob));
@@ -124,7 +124,10 @@ export default {
         "Original error",
         e
       );
-      throw Error(`Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}`, { cause: e });
+      throw Error(
+        `Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}`,
+        { cause: e }
+      );
     }
     const output: Runners | string[] = performLoadBalancing(argv.runners, argv["testing-type"] as TestingType, [
       ...new Set(files)

--- a/src/cli/commands/balance.ts
+++ b/src/cli/commands/balance.ts
@@ -28,7 +28,7 @@ export default {
   command: "$0",
   description: "Performs load balancing against a set of runners and Cypress specs",
   //@ts-expect-error Figuring out the type later
-  builder: function (yargs) {
+  builder: function(yargs) {
     return (
       yargs
         .option("runners", {
@@ -88,25 +88,25 @@ export default {
         .help()
         .alias("help", "h")
         .example(
-          'Load balancing for 6 runners against "component" testing with implied Cypress configuration of `./cypress.config.js`',
+          "Load balancing for 6 runners against \"component\" testing with implied Cypress configuration of `./cypress.config.js`",
           "npx cypressLoadBalancer -r 6 -t component"
         )
         .example(
-          'Load balancing for 6 runners against "component" testing with an explicit Cypress configuration set by an environment variable',
+          "Load balancing for 6 runners against \"component\" testing with an explicit Cypress configuration set by an environment variable",
           "CYPRESS_CONFIG_FILE=./src/tests/cypress.config.js npx cypressLoadBalancer -r 6 -t e2e"
         )
         .example(
-          'Load balancing for 3 runners against "e2e" testing with specified file paths',
+          "Load balancing for 3 runners against \"e2e\" testing with specified file paths",
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js cypress/e2e/bar.cy.js cypress/e2e/wee.cy.js"
         )
         .example(
-          'Load balancing for 3 runners against "e2e" testing with a specified glob pattern and file path',
+          "Load balancing for 3 runners against \"e2e\" testing with a specified glob pattern and file path",
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js -G cypress/e2e/more_tests/*.cy.js"
         )
     );
   },
   //@ts-expect-error Figuring out the type later
-  handler: function (argv) {
+  handler: function(argv) {
     //Assign files array to detect "--files" or files found "--glob" patterns first
     let files: string[] = argv.files;
     files.push(...glob.globSync(argv.glob));
@@ -124,6 +124,7 @@ export default {
         "Original error",
         e
       );
+      throw Error(`Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}`, { cause: e });
     }
     const output: Runners | string[] = performLoadBalancing(argv.runners, argv["testing-type"] as TestingType, [
       ...new Set(files)

--- a/src/cli/commands/balance.ts
+++ b/src/cli/commands/balance.ts
@@ -28,7 +28,7 @@ export default {
   command: "$0",
   description: "Performs load balancing against a set of runners and Cypress specs",
   //@ts-expect-error Figuring out the type later
-  builder: function (yargs) {
+  builder: function(yargs) {
     return (
       yargs
         .option("runners", {
@@ -88,25 +88,25 @@ export default {
         .help()
         .alias("help", "h")
         .example(
-          'Load balancing for 6 runners against "component" testing with implied Cypress configuration of `./cypress.config.js`',
+          "Load balancing for 6 runners against \"component\" testing with implied Cypress configuration of `./cypress.config.js`",
           "npx cypressLoadBalancer -r 6 -t component"
         )
         .example(
-          'Load balancing for 6 runners against "component" testing with an explicit Cypress configuration set by an environment variable',
+          "Load balancing for 6 runners against \"component\" testing with an explicit Cypress configuration set by an environment variable",
           "CYPRESS_CONFIG_FILE=./src/tests/cypress.config.js npx cypressLoadBalancer -r 6 -t e2e"
         )
         .example(
-          'Load balancing for 3 runners against "e2e" testing with specified file paths',
+          "Load balancing for 3 runners against \"e2e\" testing with specified file paths",
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js cypress/e2e/bar.cy.js cypress/e2e/wee.cy.js"
         )
         .example(
-          'Load balancing for 3 runners against "e2e" testing with a specified glob pattern and file path',
+          "Load balancing for 3 runners against \"e2e\" testing with a specified glob pattern and file path",
           "npx cypressLoadBalancer -r 3 -t e2e -F cypress/e2e/foo.cy.js -G cypress/e2e/more_tests/*.cy.js"
         )
     );
   },
   //@ts-expect-error Figuring out the type later
-  handler: function (argv) {
+  handler: function(argv) {
     //Assign files array to detect "--files" or files found "--glob" patterns first
     let files: string[] = argv.files;
     files.push(...glob.globSync(argv.glob));
@@ -124,10 +124,8 @@ export default {
         "Original error",
         e
       );
-      throw Error(
-        `Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}`,
-        { cause: e }
-      );
+      //TODO: add custom error and pass cause to `console.error
+      throw Error(`Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type. Provided testing type: ${argv[`testing-type`] || "undefined"}\n${e}`);
     }
     const output: Runners | string[] = performLoadBalancing(argv.runners, argv["testing-type"] as TestingType, [
       ...new Set(files)

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,0 +1,13 @@
+import { TestingType } from "../types";
+
+export class GetSpecsError extends Error {
+  public readonly testingType: TestingType;
+  public readonly options?: unknown;
+
+  constructor(testingType: TestingType, options?: { cause?: unknown }) {
+    super(`Could not run "getSpecs" most likely do to an incorrect Cypress configuration or missing testing type.`);
+    this.name = "GetSpecsError";
+    this.testingType = testingType;
+    this.options = options;
+  }
+}


### PR DESCRIPTION
I cannot remember why I let it silently fail but it cannot be allowed. When "getSpecs" fails (most likely due to an incorrect Cypress configuration), this command should fail as well.