### PR TITLE
v1.0.7 | Fix "debug-js" to use the default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-load-balancer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Zachary J. Hamm",
   "license": "MIT",
   "repository": "https://github.com/hammzj/cypress-load-balancer/",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,3 @@
-import { debug as debugInitializer } from "debug";
+import { default as debugInitializer } from "debug";
 
 export const debug = debugInitializer("cypress-load-balancer");


### PR DESCRIPTION
See [debug-js #1001](https://github.com/debug-js/debug/issues/1001).

This needs to use the default export.