### PR TITLE
Optimize "weighted-largest" algorithm & update workflow job versions

### DIFF
--- a/.github/workflows/example-parallel-testing-workflow.yml
+++ b/.github/workflows/example-parallel-testing-workflow.yml
@@ -39,14 +39,14 @@ jobs:
     name: Save the original map to cache to use on all future run attempts of this workflow
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Check if "ORIGINAL" map exists, and if not, restore cache of the map from previous workflow runs
         id: check-if-original-map-exists
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           fail-on-cache-miss: false
           path: .cypress_load_balancer/spec-map.json
@@ -59,6 +59,7 @@ jobs:
           restore-keys: |
             cypress-load-balancer-map-${{ github.head_ref || github.ref_name }}-
             cypress-load-balancer-map-${{ github.base_ref || 'main' }}
+            cypress-load-balancer-map-main
 
       - name: Initialize map if not present
         if: ${{ hashFiles('.cypress_load_balancer/**/spec-map.json') == '' }}
@@ -69,7 +70,7 @@ jobs:
 
       - name: Cache "ORIGINAL" map for all future run attempts on cache miss
         if: ${{ steps.check-if-original-map-exists.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: cypress-load-balancer-map-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}-ORIGINAL
           path: .cypress_load_balancer/spec-map.json
@@ -79,8 +80,8 @@ jobs:
     outputs:
       runner-variables: ${{ steps.generate-runners.outputs.runner-variables }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       # "npm run build" is only needed for this project to build the CLI ! It shouldn't be required in other projects as the CLI scripts should be installed normally
@@ -100,20 +101,20 @@ jobs:
       matrix:
         runner: ${{ fromJson(needs.generate_runner_variables.outputs.runner-variables) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore "ORIGINAL" load-balancing map for this run attempt
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           fail-on-cache-miss: true
           path: .cypress_load_balancer/spec-map.json
           key: cypress-load-balancer-map-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}-ORIGINAL
 
       - name: Cypress e2e tests (${{ matrix.runner }})
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           browser: electron
           # Fix for https://github.com/cypress-io/github-action/issues/480
@@ -124,7 +125,7 @@ jobs:
 
       - name: Upload temp load balancer map
         if: (!cancelled())
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Artifacts cannot be saved with a forward slash ( / ), so using runner.name as it is unique
           name: spec-map-${{ runner.name }}
@@ -137,23 +138,23 @@ jobs:
     needs: [cypress_run_e2e]
     if: (!cancelled())
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - run: npm ci && npm run build
 
       - name: Restore "ORIGINAL" load-balancing map for this run attempt
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           fail-on-cache-miss: true
           path: .cypress_load_balancer/spec-map.json
           key: cypress-load-balancer-map-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}-ORIGINAL
 
       - name: Download temp maps
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: spec-map-*
           path: temp
@@ -164,7 +165,7 @@ jobs:
 
       - name: Save overwritten cached load-balancing map to workflow
         id: cache-save-load-balancing-map
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           # This saves to the workflow run.
           # To save to the base branch during pull requests, this needs to be uploaded on merge using a separate action.
@@ -177,7 +178,7 @@ jobs:
       # That way, we can merge the source (head) branch's load balancer map to the target (base) branch.
       - name: Upload main load balancer map
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cypress-load-balancer-map
           path: .cypress_load_balancer/spec-map.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ jobs:
     name: TypeScript Checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: |
@@ -20,8 +20,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
 
       # Ensure npm 11.5.1 or later is installed

--- a/.github/workflows/save-map-to-base-branch-on-pr-merge.yml
+++ b/.github/workflows/save-map-to-base-branch-on-pr-merge.yml
@@ -20,9 +20,9 @@ jobs:
       - run: |
           echo PR #${{ github.event.number }} has been merged
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -31,7 +31,7 @@ jobs:
       # Until I can figure out a better way to access cache on head branch, we will need to download it as an artifact
       #      - name: Restore cached load-balancing map on head branch
       #        id: cache-restore-load-balancing-map-head-branch
-      #        uses: actions/cache/restore@v4
+      #        uses: actions/cache/restore@v5
       #        with:
       #          fail-on-cache-miss: true
       #          path: .cypress_load_balancer/spec-map.json
@@ -43,7 +43,7 @@ jobs:
       # Which means running the tests on the base branch!
       #      - name: Restore cached load-balancing map on head branch
       #        id: cache-restore-load-balancing-map-head-branch
-      #        uses: actions/cache/restore@v4
+      #        uses: actions/cache/restore@v5
       #        with:
       #          fail-on-cache-miss: true
       #          path: .cypress_load_balancer/spec-map.json
@@ -74,12 +74,12 @@ jobs:
         run: npx cypress-load-balancer merge -G "./temp/**/spec-map-*.json" -G "./temp/**/spec-map.json" --HE error
 
       - name: Save cache of merged load-balancing map
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .cypress_load_balancer/spec-map.json
           key: cypress-load-balancer-map-${{ github.base_ref }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cypress-load-balancer-map
           path: .cypress_load_balancer/spec-map.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Run unit tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-load-balancer",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Zachary J. Hamm",
   "license": "MIT",
   "repository": "https://github.com/hammzj/cypress-load-balancer/",

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -115,18 +115,19 @@ export class LoadBalancer {
       return arr.filter((n) => !Number.isNaN(n) || n != null).reduce((acc, next) => acc + next, 0);
     };
     const getTotalTime = (testFiles: TestFile[]) => sum(testFiles.map((tf) => tf.getMedian()));
-    const addHighestFileToTestSet = (testSet: TestFile[]) => {
+    const addHighestFileToTestSet = (testSetIndex: number) => {
       const testFile = sortedTestFiles.shift();
       if (testFile == null) {
         debug("No more files");
         return;
       }
-      testSet.push(testFile);
+      testSets[i].push(testFile);
+      testSetTimings[i] += testFile.getMedian();
     };
 
     //Sort descending order by median runtime
     const sortedTestFiles: TestFile[] = testFiles.toSorted(
-      (a: TestFile, b: TestFile) => getTotalTime([b]) - getTotalTime([a])
+      (a: TestFile, b: TestFile) => b.getMedian() - a.getMedian())
     );
 
     if (runnerCount === 1) return [sortedTestFiles];
@@ -135,6 +136,8 @@ export class LoadBalancer {
     const indexOfNewFile = sortedTestFiles.findIndex((tf) => tf.isNewFile());
     const brandNewFiles = indexOfNewFile > -1 ? sortedTestFiles.splice(indexOfNewFile) : [];
     const testSets: TestSets = Array.from({ length: runnerCount }, () => []);
+    const testSetTimings: number[] = Array.from({ length: runnerCount }, () => 0);
+    let highestIndex = 0;
 
     //Debugging purposes only
     let currentIteration = 0;
@@ -147,28 +150,25 @@ export class LoadBalancer {
 
       //When all runners are equal in time, pop out the file with the next highest runtime for each runner
       //This will prevent a deadlock state while also keeping files evenly spread amongst runners while still balanced
-      if (testSets.every((ts) => getTotalTime(ts) === getTotalTime(testSets[0]))) {
-        testSets.map(addHighestFileToTestSet);
+      if (testSetTimings.every((t) => t === testSetTimings[0])) {
+        testSets.map((_, i) => addHighestFileToTestSet(i));
       }
 
-      //Get the highest runner runtime of this iteration to compare against the other smaller runners
-      testSets.sort((a, b) => getTotalTime(a) - getTotalTime(b));
-      const highestRunTime = getTotalTime(testSets[testSets.length - 1]);
+      highestIndex = testSetTimings.indexOf(Math.Max(...testSetTimings));
 
       debug(`%s Sorted runner configurations for the current iteration: %o`, `weighted-largest`, testSets);
-      debug("Current highest runtime: %d", highestRunTime);
+      debug("Current highest runtime: %d", testSetTimings[i]);
 
       /*
       For each test set besides the largest,
       Put a file into each one, starting from the smallest.
       Repeat until there are no more files, or if rebalancing needs to occur.
        */
-      for (let i = 0; i <= testSets.length - 2; i++) {
+      for (let i = 0; i <= testSets.length - 1; i++) {
         if (sortedTestFiles.length === 0) break performIteration;
-
-        const currentTestSet = testSets[i];
-        if (getTotalTime(currentTestSet) >= highestRunTime) continue;
-        addHighestFileToTestSet(currentTestSet);
+        if (i === highestIndex) continue;
+        addHighestFileToTestSet(i);
+        if (testSetTimings[i] > testSetTimings[highestIndex]) highestIndex = i
       }
     } while (sortedTestFiles.length > 0);
 
@@ -181,7 +181,7 @@ export class LoadBalancer {
     debug(
       `%s Total run time of each runner: %o`,
       `weighted-largest`,
-      testSets.map((r, i) => `Runner ${i}: ${getTotalTime(r)}`)
+      testSets.map((_, i) => `Runner ${i}: ${testSetTimings(i)}`)
     );
     debug(`%s Completed load balancing algorithm`, `weighted-largest`);
 

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -4,10 +4,6 @@ import { debug } from "./helpers";
 
 type TestSets = TestFile[][];
 
-function filterOutEmptyArrays<T>(arr: T[]): T[] {
-  return arr.filter((v) => v != null);
-}
-
 export class LoadBalancer {
   private loadBalancingMap: LoadBalancingMap;
 
@@ -169,11 +165,7 @@ export class LoadBalancer {
 
     if (brandNewFiles.length > 0) {
       debug("Handling for %d new files", brandNewFiles.length);
-      //This will have the same number of runners as well
-      //reverse so less files are placed in largest runners first
-      this.balanceByMatchingArrayIndices(runnerCount, brandNewFiles)
-        .reverse()
-        .map((tfs, i) => getRunners()[i].push(...tfs));
+      this.balanceByMatchingArrayIndices(runnerCount, brandNewFiles).map((tfs, i) => getRunners()[i].push(...tfs));
     }
 
     debug(`%s Total iterations: %d`, `weighted-largest`, currentIteration);
@@ -191,7 +183,10 @@ export class LoadBalancer {
      * This is to make sure if there is additional filtering that means less files than runners,
      * then the earlier runners will have files and the later runners are empty.
      */
-    return tuples.toSorted((a, b) => b[1] - a[1]).map((tu) => filterOutEmptyArrays(tu[0]));
+    return tuples
+      .filter(([tfs]) => tfs.map((v) => v != null))
+      .toSorted((a, b) => b[1] - a[1])
+      .map(([tfs]) => tfs);
   }
 
   /**

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -158,11 +158,11 @@ export class LoadBalancer {
       Put a file into each one, starting from the smallest.
       Repeat until there are no more files, or if rebalancing needs to occur.
        */
-      for (let i = testSets.length - 1; i >= 0; i--) {
-        if (sortedTestFiles.length === 0) break performIteration;
-        if (i === hi || testSetTimings[i] >= testSetTimings[hi]) continue;
-        addHighestFileToTestSet(i);
-        if (testSetTimings[i] > testSetTimings[hi]) hi = i;
+      for (let i = testSets.length - 1; i >= 0 && sortedTestFiles.length > 0; i--) {
+        if (i !== hi && testSetTimings[i] < testSetTimings[hi]) {
+          addHighestFileToTestSet(i);
+          if (testSetTimings[i] > testSetTimings[hi]) hi = i;
+        }
       }
     } while (sortedTestFiles.length > 0);
 

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -88,14 +88,15 @@ export class LoadBalancer {
    * This algorithm involves making the slowest runners as fast as possible, or other runners equal to it
    *
    * Approach:
-   * - Initialize arrays of X runners and X timings associated per runner.
+   * - Initialize X number of tuples, containing a list of files and their aggregate total timings, for each runner.
    * - This section is repeated:
-   * - RoundRobin: Pop out the top "X" times and put it into each runner as its starting value.
-   * - Record the index of the largest runner as "hi".
-   * - Balance By Highest RunTime: For each runner starting with the smallest, check if its timing is smaller than the largest, and if so, add a file to it.
-   * - Re-record the highest time: Set the new "hi" if the current runner has a larger time.
+   * - RoundRobin: Pop out the top "X" files and put it into each tuple as its starting value. Add each timing to their aggregates as well.
+   * - Record the index of the tuple with the highest time as "hi".
+   * - Balance By Highest RunTime: For each tuples starting with the smallest, check if its timing is smaller than the largest, and if so, add a file to its array of test files.
+   * - Re-record the highest time: Set the new "hi" if the current tuple has a larger time.
    * - Move to next runner.
-   * - If there are more files left, then repeat against all runners, until there are no more times left to place into the runners.
+   * - If there are more files left, then repeat against all tuples, until there are no more left to place into the tuples.
+   * - Finally, return only the test file arrays, sorted from largest to smallest, with empties filtered out.
    *
    * **Use cases**: This should be the default approach, since most test executions
    * will need to wait for the longest test to complete in order to continue post-execution operations.
@@ -107,18 +108,14 @@ export class LoadBalancer {
    * @param testFiles {TestFile[]}
    */
   private balanceByWeightedLargestRunner(runnerCount: number, testFiles: TestFile[]): TestSets {
-    const sum = (arr: number[]): number => {
-      return arr.filter((n) => !Number.isNaN(n) || n != null).reduce((acc, next) => acc + next, 0);
-    };
-    const getTotalTime = (testFiles: TestFile[]) => sum(testFiles.map((tf) => tf.getMedian()));
     const addHighestFileToTestSet = (i: number) => {
       const testFile = sortedTestFiles.shift();
       if (testFile == null) {
         debug("No more files");
         return;
       }
-      testSets[i].push(testFile);
-      testSetTimings[i] += testFile.getMedian();
+      tuples[i][0].push(testFile);
+      tuples[i][1] += testFile.getMedian();
     };
 
     //Sort descending order by median runtime
@@ -129,8 +126,12 @@ export class LoadBalancer {
     //Splice array from files without durations to be handled later
     const indexOfNewFile = sortedTestFiles.findIndex((tf) => tf.isNewFile());
     const brandNewFiles = indexOfNewFile > -1 ? sortedTestFiles.splice(indexOfNewFile) : [];
-    const testSets: TestSets = Array.from({ length: runnerCount }, () => []);
-    const testSetTimings: number[] = Array.from({ length: runnerCount }, () => 0);
+
+    //Tuples of test Files and their total aggregated file timings
+    const tuples = Array.from<number, [TestFile[], number]>({ length: runnerCount }, () => [[], 0]);
+    const getRunners = () => tuples.map(([tfs]) => tfs);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const getTimings = () => tuples.map(([_, timing]) => timing);
 
     //Index of runner with highest timing ("highest index")
     let hi = 0;
@@ -144,38 +145,42 @@ export class LoadBalancer {
 
       //When all runners are equal in time, pop out the file with the next highest runtime for each runner
       //This will prevent a deadlock state while also keeping files evenly spread amongst runners while still balanced
-      if (testSetTimings.every((t) => t === testSetTimings[0])) {
-        testSets.map((_, i) => addHighestFileToTestSet(i));
-      }
 
-      hi = testSetTimings.indexOf(Math.max(...testSetTimings));
+      const allEqualTimings = getTimings().every((t) => t === tuples[0][1]);
+      if (allEqualTimings) tuples.map((_, i) => addHighestFileToTestSet(i));
 
-      debug(`%s Sorted runner configurations for the current iteration: %o`, `weighted-largest`, testSets);
-      debug("Current highest runtime: %d", testSetTimings[hi]);
+      hi = getTimings().indexOf(Math.max(...getTimings()));
+
+      debug(`%s Sorted runner configurations for the current iteration: %o`, `weighted-largest`, getRunners());
+      debug("Current highest runtime: %d", tuples[hi][1]);
 
       /*
       For each test set besides the largest,
       Put a file into each one, starting from the smallest.
       Repeat until there are no more files, or if rebalancing needs to occur.
        */
-      for (let i = testSets.length - 1; i >= 0 && sortedTestFiles.length > 0; i--) {
-        if (i !== hi && testSetTimings[i] < testSetTimings[hi]) {
+      for (let i = tuples.length - 1; i >= 0 && sortedTestFiles.length > 0; i--) {
+        if (i !== hi && getTimings()[i] < getTimings()[hi]) {
           addHighestFileToTestSet(i);
-          if (testSetTimings[i] > testSetTimings[hi]) hi = i;
+          if (getTimings()[i] > getTimings()[hi]) hi = i;
         }
       }
     } while (sortedTestFiles.length > 0);
 
     if (brandNewFiles.length > 0) {
       debug("Handling for %d new files", brandNewFiles.length);
-      this.balanceByMatchingArrayIndices(runnerCount, brandNewFiles).map((ts, i) => testSets[i].push(...ts));
+      //This will have the same number of runners as well
+      //reverse so less files are placed in largest runners first
+      this.balanceByMatchingArrayIndices(runnerCount, brandNewFiles)
+        .reverse()
+        .map((tfs, i) => getRunners()[i].push(...tfs));
     }
 
     debug(`%s Total iterations: %d`, `weighted-largest`, currentIteration);
     debug(
       `%s Total run time of each runner: %o`,
       `weighted-largest`,
-      testSets.map((_, i) => `Runner ${i}: ${testSetTimings[i]}`)
+      getTimings().map((timing, i) => `Runner ${i}: ${timing}`)
     );
     debug(`%s Completed load balancing algorithm`, `weighted-largest`);
 
@@ -186,9 +191,7 @@ export class LoadBalancer {
      * This is to make sure if there is additional filtering that means less files than runners,
      * then the earlier runners will have files and the later runners are empty.
      */
-    return testSets
-      .map(filterOutEmptyArrays<TestFile>)
-      .toSorted((a: TestFile[], b: TestFile[]) => getTotalTime(b) - getTotalTime(a));
+    return tuples.toSorted((a, b) => b[1] - a[1]).map((tu) => filterOutEmptyArrays(tu[0]));
   }
 
   /**

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -138,7 +138,7 @@ export class LoadBalancer {
     //Debugging purposes only
     let currentIteration = 0;
 
-    performIteration: do {
+    do {
       debug(`%s Current Iteration: %d`, `weighted-largest`, ++currentIteration);
       if (sortedTestFiles.length === 0) break;
 

--- a/src/load.balancer.ts
+++ b/src/load.balancer.ts
@@ -76,7 +76,6 @@ export class LoadBalancer {
   }
 
   /**
-   * @TODO: use a priority queue instead of constantly sorting
    * Attempts to get a uniform total run time between all runners by separating the longest-running tests
    * into their own runners first, and attempting to keep all other runners equal to or lower than its time.
    * If there are more tests than runners, then it will continually keep a check of the total run time of
@@ -89,23 +88,20 @@ export class LoadBalancer {
    * This algorithm involves making the slowest runners as fast as possible, or other runners equal to it
    *
    * Approach:
-   * - Initialize an array of X runners.
-   * - Sort the filePaths by their stats, from longest to shortest median time.
-   * - Record the highest median time as a temporary value of "highestRunnerTime".
+   * - Initialize arrays of X runners and X timings associated per runner.
    * - This section is repeated:
    * - RoundRobin: Pop out the top "X" times and put it into each runner as its starting value.
-   * - Balance By Highest RunTime: Take the next runner that has a total time lower than the "highestRunnerTime" and fill it with the smallest
-   * time values until it is greater than the "highestRunnerTime".
-   * - Re-record the highest time: Set the new "highestRunnerTime" if that runner has a larger time.
-   * - Move on to the next runner.
+   * - Record the index of the largest runner as "hi".
+   * - Balance By Highest RunTime: For each runner starting with the smallest, check if its timing is smaller than the largest, and if so, add a file to it.
+   * - Re-record the highest time: Set the new "hi" if the current runner has a larger time.
+   * - Move to next runner.
    * - If there are more files left, then repeat against all runners, until there are no more times left to place into the runners.
-   *
    *
    * **Use cases**: This should be the default approach, since most test executions
    * will need to wait for the longest test to complete in order to continue post-execution operations.
    * If all parallelized jobs are within the same time frame as the single longest test, then it should
    * still make the Cypress execution faster than the other algorithms.
-   * **Tradeoffs**: Runner times are more uniform, but there could be a larger set of slow runners overall. Could be a slow O-time and memory heavy; has not been calculated.
+   * **Tradeoffs**: Runner times are more uniform, but there could be a larger set of slow runners overall.
    *
    * @param runnerCount {number}
    * @param testFiles {TestFile[]}
@@ -115,7 +111,7 @@ export class LoadBalancer {
       return arr.filter((n) => !Number.isNaN(n) || n != null).reduce((acc, next) => acc + next, 0);
     };
     const getTotalTime = (testFiles: TestFile[]) => sum(testFiles.map((tf) => tf.getMedian()));
-    const addHighestFileToTestSet = (testSetIndex: number) => {
+    const addHighestFileToTestSet = (i: number) => {
       const testFile = sortedTestFiles.shift();
       if (testFile == null) {
         debug("No more files");
@@ -126,9 +122,7 @@ export class LoadBalancer {
     };
 
     //Sort descending order by median runtime
-    const sortedTestFiles: TestFile[] = testFiles.toSorted(
-      (a: TestFile, b: TestFile) => b.getMedian() - a.getMedian())
-    );
+    const sortedTestFiles: TestFile[] = testFiles.toSorted((a: TestFile, b: TestFile) => b.getMedian() - a.getMedian());
 
     if (runnerCount === 1) return [sortedTestFiles];
 
@@ -137,13 +131,13 @@ export class LoadBalancer {
     const brandNewFiles = indexOfNewFile > -1 ? sortedTestFiles.splice(indexOfNewFile) : [];
     const testSets: TestSets = Array.from({ length: runnerCount }, () => []);
     const testSetTimings: number[] = Array.from({ length: runnerCount }, () => 0);
-    let highestIndex = 0;
+
+    //Index of runner with highest timing ("highest index")
+    let hi = 0;
 
     //Debugging purposes only
     let currentIteration = 0;
 
-    //This could be done more efficiently by using array indices alongside an array of every test sets' total time,
-    // instead of resorting each iteration.
     performIteration: do {
       debug(`%s Current Iteration: %d`, `weighted-largest`, ++currentIteration);
       if (sortedTestFiles.length === 0) break;
@@ -154,21 +148,21 @@ export class LoadBalancer {
         testSets.map((_, i) => addHighestFileToTestSet(i));
       }
 
-      highestIndex = testSetTimings.indexOf(Math.Max(...testSetTimings));
+      hi = testSetTimings.indexOf(Math.max(...testSetTimings));
 
       debug(`%s Sorted runner configurations for the current iteration: %o`, `weighted-largest`, testSets);
-      debug("Current highest runtime: %d", testSetTimings[i]);
+      debug("Current highest runtime: %d", testSetTimings[hi]);
 
       /*
       For each test set besides the largest,
       Put a file into each one, starting from the smallest.
       Repeat until there are no more files, or if rebalancing needs to occur.
        */
-      for (let i = 0; i <= testSets.length - 1; i++) {
+      for (let i = testSets.length - 1; i >= 0; i--) {
         if (sortedTestFiles.length === 0) break performIteration;
-        if (i === highestIndex) continue;
+        if (i === hi || testSetTimings[i] >= testSetTimings[hi]) continue;
         addHighestFileToTestSet(i);
-        if (testSetTimings[i] > testSetTimings[highestIndex]) highestIndex = i
+        if (testSetTimings[i] > testSetTimings[hi]) hi = i;
       }
     } while (sortedTestFiles.length > 0);
 
@@ -181,7 +175,7 @@ export class LoadBalancer {
     debug(
       `%s Total run time of each runner: %o`,
       `weighted-largest`,
-      testSets.map((_, i) => `Runner ${i}: ${testSetTimings(i)}`)
+      testSets.map((_, i) => `Runner ${i}: ${testSetTimings[i]}`)
     );
     debug(`%s Completed load balancing algorithm`, `weighted-largest`);
 

--- a/tests/load.balancer.test.ts
+++ b/tests/load.balancer.test.ts
@@ -197,14 +197,13 @@ describe("LoadBalancer", function () {
           const expectedRunTime = 200;
 
           expect(getTotalMedianTime(this.jsonFixture, "e2e", runners[0])).to.eq(expectedRunTime);
+
+          //200 median time
           for (const r of runners) assertTotalRunnerTime(this.jsonFixture, "e2e", r, expectedRunTime);
           expect(runners).to.have.deep.members([
-            //200 median time
-            ["100.1.test.ts", "75.3.test.ts", "10.1.test.ts", "10.2.test.ts", "5.1.test.ts"],
-            //200 median time
-            ["150.1.test.ts", "25.1.test.ts", "25.2.test.ts"],
-            //200 median time
-            ["75.1.test.ts", "75.2.test.ts", "50.1.test.ts"]
+            ["150.1.test.ts", "50.1.test.ts"],
+            ["100.1.test.ts", "75.3.test.ts", "25.2.test.ts"],
+            ["75.1.test.ts", "75.2.test.ts", "25.1.test.ts", "10.1.test.ts", "10.2.test.ts", "5.1.test.ts"]
           ]);
         });
 
@@ -217,10 +216,10 @@ describe("LoadBalancer", function () {
           expect(getTotalMedianTime(this.jsonFixture, "e2e", runners[0])).to.eq(expectedRunTime);
           for (const r of runners) assertTotalRunnerTime(this.jsonFixture, "e2e", r, expectedRunTime);
           expect(runners).to.have.deep.members([
+            ["150.1.test.ts"],
             ["100.1.test.ts", "25.1.test.ts", "10.1.test.ts", "10.2.test.ts", "5.1.test.ts"],
-            ["75.2.test.ts", "50.1.test.ts", "25.2.test.ts"],
-            ["75.1.test.ts", "75.3.test.ts"],
-            ["150.1.test.ts"]
+            ["75.1.test.ts", "50.1.test.ts", "25.2.test.ts"],
+            ["75.2.test.ts", "75.3.test.ts"]
           ]);
         });
 
@@ -234,11 +233,11 @@ describe("LoadBalancer", function () {
             //105 Total run time
             ["100.1.test.ts", "5.1.test.ts"],
             //100 Total run time
-            ["75.1.test.ts", "25.2.test.ts"],
+            ["75.3.test.ts", "25.2.test.ts"],
+            //85 Total run time
+            ["75.1.test.ts", "10.2.test.ts"],
             //85 Total run time
             ["75.2.test.ts", "10.1.test.ts"],
-            //85 Total run time
-            ["75.3.test.ts", "10.2.test.ts"],
             //75 Total run time
             ["50.1.test.ts", "25.1.test.ts"]
           ]);
@@ -336,17 +335,17 @@ describe("LoadBalancer", function () {
 
         const runners = new LoadBalancer("weighted-largest").performLoadBalancing(3, "e2e", e2eFilePaths);
         expect(runners).to.have.deep.members([
+          ["150.1.test.ts", "50.1.test.ts", "newFile.1.test.ts", "newFile.4.test.ts"],
+          ["100.1.test.ts", "75.3.test.ts", "25.2.test.ts", "newFile.2.test.ts"],
           [
-            "100.1.test.ts",
-            "75.3.test.ts",
+            "75.1.test.ts",
+            "75.2.test.ts",
+            "25.1.test.ts",
             "10.1.test.ts",
             "10.2.test.ts",
             "5.1.test.ts",
-            "newFile.1.test.ts",
-            "newFile.4.test.ts"
-          ],
-          ["150.1.test.ts", "25.1.test.ts", "25.2.test.ts", "newFile.2.test.ts"],
-          ["75.1.test.ts", "75.2.test.ts", "50.1.test.ts", "newFile.3.test.ts"]
+            "newFile.3.test.ts"
+          ]
         ]);
       });
 
@@ -414,35 +413,6 @@ describe("LoadBalancer", function () {
           expect(runners.map((r) => getTotalMedianTime(this.jsonFixture, "e2e", r))).to.deep.equal([601, 600, 600]);
           expect(runners).to.deep.equal([
             [
-              "90.1.test.ts",
-              "80.1.test.ts",
-              "70.1.test.ts",
-              "70.4.test.ts",
-              "60.5.test.ts",
-              "50.3.test.ts",
-              "50.6.test.ts",
-              "40.3.test.ts",
-              "30.1.test.ts",
-              "30.2.test.ts",
-              "20.1.test.ts",
-              "10.1.test.ts",
-              "1.1.test.ts"
-            ],
-            [
-              "90.2.test.ts",
-              "80.2.test.ts",
-              "70.2.test.ts",
-              "60.1.test.ts",
-              "60.3.test.ts",
-              "50.1.test.ts",
-              "50.4.test.ts",
-              "40.1.test.ts",
-              "40.4.test.ts",
-              "30.3.test.ts",
-              "20.2.test.ts",
-              "10.2.test.ts"
-            ],
-            [
               "100.1.test.ts",
               "80.3.test.ts",
               "70.3.test.ts",
@@ -452,8 +422,37 @@ describe("LoadBalancer", function () {
               "50.5.test.ts",
               "40.2.test.ts",
               "40.5.test.ts",
+              "30.3.test.ts",
+              "20.2.test.ts",
+              "1.1.test.ts"
+            ],
+            [
+              "90.1.test.ts",
+              "80.2.test.ts",
+              "70.2.test.ts",
+              "60.1.test.ts",
+              "60.3.test.ts",
+              "50.1.test.ts",
+              "50.4.test.ts",
+              "40.1.test.ts",
+              "40.4.test.ts",
+              "30.2.test.ts",
+              "20.1.test.ts",
+              "10.1.test.ts"
+            ],
+            [
+              "90.2.test.ts",
+              "80.1.test.ts",
+              "70.1.test.ts",
+              "70.4.test.ts",
+              "60.5.test.ts",
+              "50.3.test.ts",
+              "50.6.test.ts",
+              "40.3.test.ts",
+              "30.1.test.ts",
               "30.4.test.ts",
-              "20.3.test.ts"
+              "20.3.test.ts",
+              "10.2.test.ts"
             ]
           ]);
         });
@@ -485,6 +484,7 @@ describe("LoadBalancer", function () {
 
           expect(runners.map((r) => getTotalMedianTime(this.jsonFixture, "e2e", r))).to.deep.equal([1000, 1000]);
           expect(runners).to.deep.equal([
+            ["1000.1.test.ts"],
             [
               "100.1.test.ts",
               "100.2.test.ts",
@@ -496,8 +496,7 @@ describe("LoadBalancer", function () {
               "100.8.test.ts",
               "100.9.test.ts",
               "100.10.test.ts"
-            ],
-            ["1000.1.test.ts"]
+            ]
           ]);
         });
 
@@ -515,6 +514,7 @@ describe("LoadBalancer", function () {
           const runners = new LoadBalancer("weighted-largest").performLoadBalancing(2, "e2e", this.filePaths);
           expect(runners.map((r) => getTotalMedianTime(this.jsonFixture, "e2e", r))).to.deep.equal([1100, 1000]);
           expect(runners).to.deep.equal([
+            ["1000.1.test.ts", "100.11.test.ts"],
             [
               "100.1.test.ts",
               "100.2.test.ts",
@@ -525,10 +525,8 @@ describe("LoadBalancer", function () {
               "100.7.test.ts",
               "100.8.test.ts",
               "100.9.test.ts",
-              "100.10.test.ts",
-              "100.11.test.ts"
-            ],
-            ["1000.1.test.ts"]
+              "100.10.test.ts"
+            ]
           ]);
         });
 
@@ -543,9 +541,9 @@ describe("LoadBalancer", function () {
           const runners = new LoadBalancer("weighted-largest").performLoadBalancing(3, "e2e", this.filePaths);
           expect(runners.map((r) => getTotalMedianTime(this.jsonFixture, "e2e", r))).to.deep.equal([270, 270, 260]);
           expect(runners).to.have.deep.members([
-            ["100.1.test.ts", "50.1.test.ts", "50.2.test.ts", "50.5.test.ts", "20.1.test.ts"],
-            ["90.1.test.ts", "60.1.test.ts", "50.4.test.ts", "40.1.test.ts", "30.1.test.ts"],
-            ["80.1.test.ts", "70.1.test.ts", "50.3.test.ts", "50.6.test.ts", "10.1.test.ts"]
+            ["90.1.test.ts", "60.1.test.ts", "50.3.test.ts", "50.6.test.ts", "20.1.test.ts"],
+            ["80.1.test.ts", "70.1.test.ts", "50.4.test.ts", "40.1.test.ts", "30.1.test.ts"],
+            ["100.1.test.ts", "50.1.test.ts", "50.2.test.ts", "50.5.test.ts", "10.1.test.ts"]
           ]);
         });
 
@@ -560,17 +558,9 @@ describe("LoadBalancer", function () {
           const runners = new LoadBalancer("weighted-largest").performLoadBalancing(3, "e2e", this.filePaths);
           expect(runners.map((r) => getTotalMedianTime(this.jsonFixture, "e2e", r))).to.deep.equal([300, 290, 290]);
           expect(runners).to.deep.equal([
-            [
-              "100.2.test.ts",
-              "90.1.test.ts",
-              "60.1.test.ts",
-              "20.1.test.ts",
-              "10.1.test.ts",
-              "10.3.test.ts",
-              "10.4.test.ts"
-            ],
-            ["100.3.test.ts", "80.1.test.ts", "70.1.test.ts", "30.1.test.ts", "10.2.test.ts"],
-            ["100.1.test.ts", "100.4.test.ts", "50.1.test.ts", "40.1.test.ts"]
+            ["100.1.test.ts", "100.4.test.ts", "50.1.test.ts", "40.1.test.ts", "10.4.test.ts"],
+            ["100.2.test.ts", "90.1.test.ts", "60.1.test.ts", "30.1.test.ts", "10.2.test.ts"],
+            ["100.3.test.ts", "80.1.test.ts", "70.1.test.ts", "20.1.test.ts", "10.1.test.ts", "10.3.test.ts"]
           ]);
         });
 

--- a/tests/load.balancer.test.ts
+++ b/tests/load.balancer.test.ts
@@ -335,7 +335,7 @@ describe("LoadBalancer", function () {
 
         const runners = new LoadBalancer("weighted-largest").performLoadBalancing(3, "e2e", e2eFilePaths);
         expect(runners).to.have.deep.members([
-          ["150.1.test.ts", "50.1.test.ts", "newFile.3.test.ts"],
+          ["150.1.test.ts", "50.1.test.ts", "newFile.1.test.ts", "newFile.4.test.ts"],
           ["100.1.test.ts", "75.3.test.ts", "25.2.test.ts", "newFile.2.test.ts"],
           [
             "75.1.test.ts",
@@ -344,8 +344,7 @@ describe("LoadBalancer", function () {
             "10.1.test.ts",
             "10.2.test.ts",
             "5.1.test.ts",
-            "newFile.1.test.ts",
-            "newFile.4.test.ts"
+            "newFile.3.test.ts"
           ]
         ]);
       });

--- a/tests/load.balancer.test.ts
+++ b/tests/load.balancer.test.ts
@@ -335,7 +335,7 @@ describe("LoadBalancer", function () {
 
         const runners = new LoadBalancer("weighted-largest").performLoadBalancing(3, "e2e", e2eFilePaths);
         expect(runners).to.have.deep.members([
-          ["150.1.test.ts", "50.1.test.ts", "newFile.1.test.ts", "newFile.4.test.ts"],
+          ["150.1.test.ts", "50.1.test.ts", "newFile.3.test.ts"],
           ["100.1.test.ts", "75.3.test.ts", "25.2.test.ts", "newFile.2.test.ts"],
           [
             "75.1.test.ts",
@@ -344,7 +344,8 @@ describe("LoadBalancer", function () {
             "10.1.test.ts",
             "10.2.test.ts",
             "5.1.test.ts",
-            "newFile.3.test.ts"
+            "newFile.1.test.ts",
+            "newFile.4.test.ts"
           ]
         ]);
       });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -237,7 +237,7 @@ describe("addCypressLoadBalancerPlugin", function () {
               },
               "component"
             )
-          ).to.throw("nv.runner is incorrect! The runner index cannot be greater than the total runner count: 2/1");
+          ).to.throw("env.runner is incorrect! The runner index cannot be greater than the total runner count: 2/1");
         });
 
         const test_theRunnerIndexSpecifiesTheSpecsThatWillBeRunInTheCypressProcess = [


### PR DESCRIPTION
# What
## Some hardcore optimizations to weighted-largest algorithms
* Use a tuple to track test files and the total run time per runner. The timings can be used as a lookup table to determine how to fill runners until they are even or nearly even in runtime. This replaces a repeated sorting operation on the runners and having to iterate over each file in the runner to get their total run times each iteration. Much less O(n**2) or whatever the hell it was before. 
* Also some loop improvements using black magick


## GitHub Actions version upgrades